### PR TITLE
JRTB-3: added Command pattern for handling Telegram Bot commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,10 @@
+# Release Notes
 
+## 0.1.0-SNAPSHOT
+
+* added stub telegram bot
+* added SpringBoot skeleton project
+
+## 0.2.0-SNAPSHOT
+
+* implemented Command pattern for handling Telegram bot commands

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.javarushcommunity</groupId>
 	<artifactId>javarush-telegrambot</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<name>Javarush TelegramBot</name>
 	<description>Demo project: Telegram bot for Javarush</description>
 	<properties>

--- a/src/main/java/com/github/javarushcommunity/jrtb/bot/JavaRushTelegramBot.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/bot/JavaRushTelegramBot.java
@@ -1,20 +1,32 @@
 package com.github.javarushcommunity.jrtb.bot;
 
+import com.github.javarushcommunity.jrtb.command.CommandContainer;
+import com.github.javarushcommunity.jrtb.service.SendBotMessageServiceImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
-import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import static com.github.javarushcommunity.jrtb.command.CommandName.NO;
+
+
 
 @Component
 public class JavaRushTelegramBot extends TelegramLongPollingBot {
+
+    public static String COMMAND_PREFIX = "/";
 
     @Value("${bot.username}")
     private String username;
 
     @Value("${bot.token}")
     private String token;
+
+    private final CommandContainer commandContainer;
+
+    public JavaRushTelegramBot() {
+        this.commandContainer = new CommandContainer(new SendBotMessageServiceImpl(this));
+    }
 
     @Override
     public String getBotUsername() {
@@ -30,19 +42,14 @@ public class JavaRushTelegramBot extends TelegramLongPollingBot {
     public void onUpdateReceived(Update update) {
         if (update.hasMessage() && update.getMessage().hasText()) {
             String message = update.getMessage().getText().trim();
-            String chatId = update.getMessage().getChatId().toString();
 
-            SendMessage sm = new SendMessage();
-            sm.setChatId(chatId);
-            sm.setText(message);
+            if(message.startsWith(COMMAND_PREFIX)) {
+                String commandIdentifier = message.split(" ")[0].toLowerCase();
 
-            try {
-                execute(sm);
-            } catch (TelegramApiException e) {
-                //todo logging to the project
-                e.printStackTrace();
+                commandContainer.retrieveCommand(commandIdentifier).execute(update);
+            } else {
+                commandContainer.retrieveCommand(NO.getCommandName()).execute(update);
             }
         }
-
     }
 }

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/Command.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/Command.java
@@ -1,0 +1,16 @@
+package com.github.javarushcommunity.jrtb.command;
+
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Command interface for handling telegram-bot commands.
+ */
+public interface Command {
+
+    /**
+     * Main method, which is executing command logic.
+     *
+     * @param update provided {@link Update} object with all the needed data for command.
+     */
+    void execute(Update update);
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/CommandContainer.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/CommandContainer.java
@@ -1,0 +1,26 @@
+package com.github.javarushcommunity.jrtb.command;
+
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import com.google.common.collect.ImmutableBiMap;
+
+import static com.github.javarushcommunity.jrtb.command.CommandName.*;
+
+public class CommandContainer {
+
+    private final ImmutableBiMap<String, Command> commandMap;
+    private final Command unknownCommand;
+
+    public CommandContainer(SendBotMessageService sendBotMessageService) {
+        this.commandMap = ImmutableBiMap.<String, Command>builder()
+                .put(START.getCommandName(), new StartCommand(sendBotMessageService))
+                .put(STOP.getCommandName(), new StopCommand(sendBotMessageService))
+                .put(HELP.getCommandName(), new HelpCommand(sendBotMessageService))
+                .put(NO.getCommandName(), new NoCommand(sendBotMessageService))
+                .build();
+        this.unknownCommand = new UnknownCommand(sendBotMessageService);
+    }
+
+    public Command retrieveCommand(String commandIdentifier) {
+        return commandMap.getOrDefault(commandIdentifier, unknownCommand);
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/CommandName.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/CommandName.java
@@ -1,0 +1,22 @@
+package com.github.javarushcommunity.jrtb.command;
+
+/**
+ * Enumeration for {@link Command}'s.
+ */
+public enum CommandName {
+    START("/start"),
+    STOP("/stop"),
+    HELP("/help"),
+    NO("nocommand");
+
+    private final String commandName;
+
+
+    CommandName(String commandName) {
+        this.commandName = commandName;
+    }
+
+    public String getCommandName() {
+        return commandName;
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/HelpCommand.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/HelpCommand.java
@@ -1,0 +1,31 @@
+package com.github.javarushcommunity.jrtb.command;
+
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import static com.github.javarushcommunity.jrtb.command.CommandName.*;
+
+
+/**
+ * Help {@link Command}.
+ */
+public class HelpCommand implements Command{
+
+    private final SendBotMessageService sendBotMessageService;
+    public static final String HELP_MESSAGE = String.format("✨<b>Дотупные команды</b>✨\n\n"
+
+                    + "<b>Начать\\закончить работу с ботом</b>\n"
+                    + "%s - начать работу со мной\n"
+                    + "%s - приостановить работу со мной\n\n"
+                    + "%s - получить помощь в работе со мной\n",
+            START.getCommandName(), STOP.getCommandName(), HELP.getCommandName());
+
+    public HelpCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),HELP_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/NoCommand.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/NoCommand.java
@@ -1,0 +1,21 @@
+package com.github.javarushcommunity.jrtb.command;
+
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class NoCommand implements Command {
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public static final String NO_MESSAGE = "Я поддерживаю команды, начинающиеся со слеша(/).\n"
+            + "Чтобы посмотреть список команд введите /help";
+
+    public NoCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),NO_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/StartCommand.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/StartCommand.java
@@ -1,0 +1,24 @@
+package com.github.javarushcommunity.jrtb.command;
+
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Start {@link Command}.
+ */
+public class StartCommand implements Command{
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public final static String START_MESSAGE = "Привет. Я Javarush Telegram Bot. Я помогу тебе быть в курсе последних " +
+            "статей тех авторов, котрые тебе интересны. Я еще маленький и только учусь.";
+
+    public StartCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),START_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/StopCommand.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/StopCommand.java
@@ -1,0 +1,23 @@
+package com.github.javarushcommunity.jrtb.command;
+
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Stop {@link Command}.
+ */
+public class StopCommand implements Command {
+
+    private final SendBotMessageService sendBotMessageService;
+    public static final String STOP_MESSAGE = "Деактивировал все ваши подписки \uD83D\uDE1F.";
+
+    public StopCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(),STOP_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/command/UnknownCommand.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/command/UnknownCommand.java
@@ -1,0 +1,24 @@
+package com.github.javarushcommunity.jrtb.command;
+
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Unknown {@link Command}.
+ */
+public class UnknownCommand implements Command {
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public static final String UNKNOWN_MESSAGE = "Не понимаю вас \uD83D\uDE1F, " +
+            "напишите /help чтобы узнать что я понимаю.";
+
+    public UnknownCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(), UNKNOWN_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageService.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageService.java
@@ -1,0 +1,15 @@
+package com.github.javarushcommunity.jrtb.service;
+
+/**
+ * Service for sending messages via telegram-bot.
+ */
+public interface SendBotMessageService {
+    /**
+     * Send message via telegram bot.
+     *
+     * @param chatId provided chatId in which messages would be sent.
+     * @param message provided message to be sent.
+     */
+
+    void sendMessage(String chatId, String message);
+}

--- a/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageServiceImpl.java
+++ b/src/main/java/com/github/javarushcommunity/jrtb/service/SendBotMessageServiceImpl.java
@@ -1,0 +1,37 @@
+package com.github.javarushcommunity.jrtb.service;
+
+import com.github.javarushcommunity.jrtb.bot.JavaRushTelegramBot;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+/**
+ * Implementation of {@link SendBotMessageService} interface.
+ */
+@Service
+public class SendBotMessageServiceImpl implements SendBotMessageService{
+
+    private  final JavaRushTelegramBot javaRushBot;
+
+    @Autowired
+    public SendBotMessageServiceImpl(JavaRushTelegramBot javaRushBot) {
+        this.javaRushBot = javaRushBot;
+    }
+
+
+    @Override
+    public void sendMessage(String chatId, String message) {
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setChatId(chatId);
+        sendMessage.enableHtml(true);
+        sendMessage.setText(message);
+
+        try {
+            javaRushBot.execute(sendMessage);
+        } catch (TelegramApiException e) {
+            // todo logging
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/AbstractCommandTest.java
+++ b/src/test/java/AbstractCommandTest.java
@@ -1,0 +1,45 @@
+import com.github.javarushcommunity.jrtb.bot.JavaRushTelegramBot;
+import com.github.javarushcommunity.jrtb.command.Command;
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import com.github.javarushcommunity.jrtb.service.SendBotMessageServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+abstract class AbstractCommandTest {
+
+    protected JavaRushTelegramBot javaRushBot = Mockito.mock(JavaRushTelegramBot.class);
+    protected SendBotMessageService sendBotMessageService = new SendBotMessageServiceImpl(javaRushBot);
+
+    abstract String getCommandName();
+
+    abstract String getCommandMessage();
+
+    abstract Command getCommand();
+
+    @Test
+    public void shouldProperlyExecuteCommand() throws TelegramApiException {
+        // given
+        Long chatId = 123456789L;
+
+        Update update = new Update();
+        Message message = Mockito.mock(Message.class);
+        Mockito.when(message.getChatId()).thenReturn(chatId);
+        Mockito.when(message.getText()).thenReturn(getCommandName());
+        update.setMessage(message);
+
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setChatId(chatId.toString());
+        sendMessage.setText(getCommandMessage());
+        sendMessage.enableHtml(true);
+
+        // when
+        getCommand().execute(update);
+
+        // then
+        Mockito.verify(javaRushBot).execute(sendMessage);
+    }
+}

--- a/src/test/java/CommandContainerTest.java
+++ b/src/test/java/CommandContainerTest.java
@@ -1,0 +1,45 @@
+import com.github.javarushcommunity.jrtb.command.Command;
+import com.github.javarushcommunity.jrtb.command.CommandContainer;
+import com.github.javarushcommunity.jrtb.command.CommandName;
+import com.github.javarushcommunity.jrtb.command.UnknownCommand;
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+public class CommandContainerTest {
+
+    private CommandContainer commandContainer;
+
+    @BeforeEach
+    public void init() {
+        SendBotMessageService sendBotMessageService = Mockito.mock(SendBotMessageService.class);
+        commandContainer = new CommandContainer(sendBotMessageService);
+    }
+
+    @Test
+    public void shouldGetAllTheExistingCommands() {
+        //when-then
+        Arrays.stream(CommandName.values())
+                .forEach(commandName -> {
+                    Command command = commandContainer.retrieveCommand(commandName.getCommandName());
+                    Assertions.assertNotEquals(UnknownCommand.class, command.getClass());
+                });
+    }
+    @Test
+    public void shouldReturnUnknownCommand() {
+        //given
+        String unknownCommand = "/dsfgd";
+
+        //when
+        Command command = commandContainer.retrieveCommand(unknownCommand);
+
+        //then
+        Assertions.assertEquals(UnknownCommand.class, command.getClass());
+    }
+
+
+}

--- a/src/test/java/HelpCommandTest.java
+++ b/src/test/java/HelpCommandTest.java
@@ -1,0 +1,25 @@
+import com.github.javarushcommunity.jrtb.command.Command;
+import com.github.javarushcommunity.jrtb.command.HelpCommand;
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.javarushcommunity.jrtb.command.CommandName.HELP;
+import static com.github.javarushcommunity.jrtb.command.HelpCommand.HELP_MESSAGE;
+
+@DisplayName("Unit-level testing for HelpCommand")
+public class HelpCommandTest extends AbstractCommandTest {
+
+    @Override
+    String getCommandName() {
+        return HELP.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return HELP_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new HelpCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/NoCommandTest.java
+++ b/src/test/java/NoCommandTest.java
@@ -1,0 +1,24 @@
+import com.github.javarushcommunity.jrtb.command.Command;
+import com.github.javarushcommunity.jrtb.command.NoCommand;
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.javarushcommunity.jrtb.command.CommandName.NO;
+import static com.github.javarushcommunity.jrtb.command.NoCommand.NO_MESSAGE;
+
+@DisplayName("Unit-level testing for NoCommand")
+public class NoCommandTest extends AbstractCommandTest {
+    @Override
+    String getCommandName() {
+        return NO.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return NO_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new NoCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/SendBotMessageServiceTest.java
+++ b/src/test/java/SendBotMessageServiceTest.java
@@ -1,0 +1,42 @@
+import com.github.javarushcommunity.jrtb.service.SendBotMessageService;
+import com.github.javarushcommunity.jrtb.bot.JavaRushTelegramBot;
+import com.github.javarushcommunity.jrtb.service.SendBotMessageServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+@DisplayName("Unit-level testing for SendBotMessageService")
+public class SendBotMessageServiceTest {
+
+    private SendBotMessageService sendBotMessageService;
+    private JavaRushTelegramBot javaRushBot;
+
+    @BeforeEach
+    public void init() {
+        javaRushBot = Mockito.mock(JavaRushTelegramBot.class);
+        sendBotMessageService = new SendBotMessageServiceImpl(javaRushBot);
+    }
+
+    @Test
+    public void shouldProperlySendMessage() throws TelegramApiException {
+        // given
+        String chatId = "test_chat_id";
+        String message = "test_message";
+
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setChatId(chatId);
+        sendMessage.setText(message);
+        sendMessage.enableHtml(true);
+
+        //when
+        sendBotMessageService.sendMessage(chatId,message);
+
+        //then
+        Mockito.verify(javaRushBot).execute(sendMessage);
+    }
+
+
+}

--- a/src/test/java/StartCommandTest.java
+++ b/src/test/java/StartCommandTest.java
@@ -1,0 +1,24 @@
+import com.github.javarushcommunity.jrtb.command.Command;
+import com.github.javarushcommunity.jrtb.command.StartCommand;
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.javarushcommunity.jrtb.command.CommandName.START;
+import static com.github.javarushcommunity.jrtb.command.StartCommand.START_MESSAGE;
+
+@DisplayName("Unit-level testing for StartCommand")
+public class StartCommandTest extends AbstractCommandTest {
+    @Override
+    String getCommandName() {
+        return START.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return START_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new StartCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/StopCommandTest.java
+++ b/src/test/java/StopCommandTest.java
@@ -1,0 +1,24 @@
+import com.github.javarushcommunity.jrtb.command.Command;
+import com.github.javarushcommunity.jrtb.command.StopCommand;
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.javarushcommunity.jrtb.command.CommandName.STOP;
+import static com.github.javarushcommunity.jrtb.command.StopCommand.STOP_MESSAGE;
+
+@DisplayName("Unit-level testing for StopCommand")
+public class StopCommandTest extends AbstractCommandTest{
+    @Override
+    String getCommandName() {
+        return STOP.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return STOP_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new StopCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/UnknownCommandTest.java
+++ b/src/test/java/UnknownCommandTest.java
@@ -1,0 +1,25 @@
+import com.github.javarushcommunity.jrtb.command.Command;
+import com.github.javarushcommunity.jrtb.command.UnknownCommand;
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.javarushcommunity.jrtb.command.UnknownCommand.UNKNOWN_MESSAGE;
+
+@DisplayName("Unit-level testing for UnknownCommand")
+public class UnknownCommandTest extends AbstractCommandTest {
+
+
+    @Override
+    String getCommandName() {
+        return "/dsfsdfsdf";
+    }
+
+    @Override
+    String getCommandMessage() {
+        return UNKNOWN_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new UnknownCommand(sendBotMessageService);
+    }
+}


### PR DESCRIPTION
# PR details

Implemented Command Pattern for handling Telegram bot commands.
Added unit-test for this functionality.

## Types of changes
[x] Docs changed | refactoring | dependency upgrade
[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking changes which adds functionality)
